### PR TITLE
Colored the TabListName

### DIFF
--- a/src/main/java/com/barroncraft/sce/ExtensionsCommand.java
+++ b/src/main/java/com/barroncraft/sce/ExtensionsCommand.java
@@ -141,7 +141,9 @@ public class ExtensionsCommand
 				clan.setHomeLocation(location);
 		}
 		clan.addPlayerToClan(player);
-		player.toPlayer().teleport(clan.getHomeLocation());
+		Player p = player.toPlayer();
+		p.teleport(clan.getHomeLocation());
+		p.setPlayerListName(ChatColor.valueOf(clan.getName())+p.getName());
 	}
 	
 	private int GetOnlinePlayerCount(Clan clan)


### PR DESCRIPTION
The PlayerTabListName now gets colored depending on the players clan (might need a fix for names longer than 16 chars).
